### PR TITLE
レビュー通知をSlackに送るBOTを作る

### DIFF
--- a/.github/workflows/NoticeReview.yml
+++ b/.github/workflows/NoticeReview.yml
@@ -1,0 +1,23 @@
+name: Labeler
+on:
+  label:
+    types: [created]
+
+jobs:
+  notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        if: contains(${{github.labels}}, "review ready")
+        uses: rtCamp/action-slack-notify@v2.0.1
+        env:
+          SLACK_CHANNEL: notify-android
+          SLACK_ICON: https://github.com/actions.png?size=48
+          SLACK_TITLE: ':rocket: Review Please :rocket:'
+          SLACK_MESSAGE: |
+            レビューお願いしようと考えた時、すでに通知が終わっている...！！
+            @here (レビューお願いします）
+            ${{github.pull_request.html.href}}
+          SLACK_USERNAME: Github Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        

--- a/.github/workflows/NoticeReview.yml
+++ b/.github/workflows/NoticeReview.yml
@@ -1,14 +1,14 @@
-name: Labeler
+name: NoticeReview
 on:
   label:
-    types: [created]
+    types: [created, edited, deleted]
 
 jobs:
   notification:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        if: contains(${{github.labels}}, "review ready")
+#         if: contains(${{github.labels}}, "review ready")
         uses: rtCamp/action-slack-notify@v2.0.1
         env:
           SLACK_CHANNEL: notify-android


### PR DESCRIPTION
## TL;DR

- close #52 

## なんでこの変更が必要だった？ (必須)
Reviewの準備ができても、通知するものがなく見逃しがあるため。

## どんな変更した？ (必須)
GithubActionsでいい感じにできないか試してみた。
変更点はcommitを確認していただければ

## どうやったらこの変更を確認できる？ (必須)
commitを確認していただければ！
